### PR TITLE
SPRK-2614 relax dateutils requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author='Jan-Jelle Kester',
     description='Audit log app for Django',
     install_requires=[
-        'python-dateutil==2.6.0'
+        'python-dateutil>=2.6.0'
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Relax dateutils requirement so I can resolve a dependency resolution issue so I can upgrade arrow library to resolve a bug in date parsing in bulk trainee import. This change is already made by the upstream in its next major release.

Example of the build failures this is causing in my spark branch: https://github.com/sponge-learning/spark/actions/runs/6196279364/job/16822601511?pr=1331#step:14:6413